### PR TITLE
Add voicemail transcription to bulk account settings & fix PHP 8 count() error

### DIFF
--- a/bulk_account_settings_users.php
+++ b/bulk_account_settings_users.php
@@ -438,7 +438,7 @@
 			echo "	<td><a href='".$list_row_url."'>".escape($row['username'])."</a></td>\n";
 			echo "	<td>".escape($row['user_status'])."&nbsp;</td>\n";
 			echo "	<td>";
-				if (count($user_groups[$row['user_uuid']]) > 0) {
+				if (!empty($user_groups[$row['user_uuid']])) {
 					echo implode(', ', $user_groups[$row['user_uuid']]);
 				}
 				echo "&nbsp;</td>\n";

--- a/bulk_account_settings_voicemails.php
+++ b/bulk_account_settings_voicemails.php
@@ -48,6 +48,7 @@
 	$voicemail_options[] = 'voicemail_file';
 	$voicemail_options[] = 'voicemail_enabled';
 	$voicemail_options[] = 'voicemail_local_after_email';
+	$voicemail_options[] = 'voicemail_transcription_enabled';
 	$voicemail_options[] = 'voicemail_password';
 	$voicemail_options[] = 'voicemail_option_0';
 	$voicemail_options[] = 'voicemail_option_1';

--- a/bulk_account_settings_voicemails_update.php
+++ b/bulk_account_settings_voicemails_update.php
@@ -47,6 +47,7 @@
 	$voicemail_options[] = 'voicemail_file';
 	$voicemail_options[] = 'voicemail_enabled';
 	$voicemail_options[] = 'voicemail_local_after_email';
+	$voicemail_options[] = 'voicemail_transcription_enabled';
 	$voicemail_options[] = 'voicemail_password';
 	$voicemail_options[] = 'voicemail_option_0';
 	$voicemail_options[] = 'voicemail_option_1';


### PR DESCRIPTION
Added voicemail_transcription_enabled to the $voicemail_options array in both bulk_account_settings_voicemails.php and bulk_account_settings_voicemails_update.php, enabling bulk enable/disable of voicemail transcription from the dropdown.

Fixed count() TypeError in bulk_account_settings_users.php line 441 caused by passing null to count() when a user has no group assignments. Replaced count($user_groups[...]) > 0 with !empty($user_groups[...]) for PHP 8.x compatibility.